### PR TITLE
libnvjitlink v13.1.115

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -8,8 +8,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/README.md
+++ b/README.md
@@ -156,12 +156,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -188,7 +188,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/libnvjitlink-split-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"
+
+staging_channel_upload_target: ctk-13.1.1-build-1
+
+channels:
+  - https://staging.continuum.io/pbp/ctk-13.1.1-build-1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "libnvjitlink" %}
-{% set version = "13.1.80" %}
+{% set version = "13.1.115" %}
 {% set cuda_version = "13.1" %}
 {% set platform = "placeholder" %}  # [osx]
 {% set platform = "linux-x86_64" %}  # [linux64]
@@ -19,9 +19,9 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/{{ name }}/{{ platform }}/{{ name }}-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: 850cba213192691046441b5334588daa796c3dbce71253131fbf3c77e29ca18d  # [linux64]
-  sha256: 7ac38d1a5ba662a0a6a920068cda8999e51e9c21fc3eb0d89b0edd96202ede75  # [aarch64]
-  sha256: db9356f207bd1db91c667eba1dde4646b0176991f66c1a0bb9ca2657e88647c7  # [win]
+  sha256: c1634fd16cd4a011a57c1d07f9cbfb3bc9b9e9259d97f084a316005f30fd0f2e  # [linux64]
+  sha256: fc34407df1deb6a0c0a2c218788d32a95becad23a72de0bfab12d35d0a0d200c  # [aarch64]
+  sha256: 81768c505953e37b5beeea97dadcb7227471f8bcfa167134ca010ed52cf176af  # [win]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "libnvjitlink" %}
-{% set version = "13.0.88" %}
-{% set cuda_version = "13.0" %}
+{% set version = "13.1.80" %}
+{% set cuda_version = "13.1" %}
 {% set platform = "placeholder" %}  # [osx]
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
@@ -19,9 +19,9 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/{{ name }}/{{ platform }}/{{ name }}-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: 25f9763fd60122a4f728eec22ac4e64e46ea8679e140234f15eaec008e6c41a8  # [linux64]
-  sha256: b7c25896af24ea88309301c8325449cd3d4907b3f1db4060f43a8ca8f4738cdc  # [aarch64]
-  sha256: 4b2cff3cfcec50cab2193f11cee023589b1b3b15388ab38780ea08b7ebbf15e3  # [win]
+  sha256: 850cba213192691046441b5334588daa796c3dbce71253131fbf3c77e29ca18d  # [linux64]
+  sha256: 7ac38d1a5ba662a0a6a920068cda8999e51e9c21fc3eb0d89b0edd96202ede75  # [aarch64]
+  sha256: db9356f207bd1db91c667eba1dde4646b0176991f66c1a0bb9ca2657e88647c7  # [win]
 
 build:
   number: 0


### PR DESCRIPTION
libnvjitlink 13.1.115

**Destination channel:** defaults

### Links

- [PKG-12020](https://anaconda.atlassian.net/browse/PKG-12020) 
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- CUDA 13.1 release


[PKG-12020]: https://anaconda.atlassian.net/browse/PKG-12020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ